### PR TITLE
Refactor/rotate gizmo

### DIFF
--- a/Circle.cpp
+++ b/Circle.cpp
@@ -1,0 +1,28 @@
+﻿#include "Object/Actor/Circle.h"
+
+#include <Object/PrimitiveComponent/UPrimitiveComponent.h>
+
+ACircle::ACircle()
+{
+    bCanEverTick = true;
+
+    UCircleComp* CircleComponent = AddComponent<UCircleComp>();
+    RootComponent = CircleComponent;
+
+    SetActorTransform(FTransform());
+}
+
+void ACircle::BeginPlay()
+{
+    Super::BeginPlay();
+}
+
+void ACircle::Tick(float DeltaTime)
+{
+    Super::Tick(DeltaTime);
+}
+
+const char* ACircle::GetTypeName()
+{
+    return "Circle";
+}

--- a/Source/Core/Input/PlayerController.cpp
+++ b/Source/Core/Input/PlayerController.cpp
@@ -33,7 +33,7 @@ void APlayerController::HandleCameraMovement(float DeltaTime) {
     FTransform CameraTransform = Camera->GetActorTransform();
 
     FVector TargetRotation = CameraTransform.GetRotation().GetEuler();
-    TargetRotation.Y += Camera->CameraSpeed * -DeltaPos.Y * DeltaTime;
+    TargetRotation.Y += Camera->CameraSpeed * DeltaPos.Y * DeltaTime;
     TargetRotation.Z += Camera->CameraSpeed * DeltaPos.X * DeltaTime;
     
     TargetRotation.Y = FMath::Clamp(TargetRotation.Y, -Camera->MaxYDegree, Camera->MaxYDegree);

--- a/Source/Core/Math/Matrix.cpp
+++ b/Source/Core/Math/Matrix.cpp
@@ -221,41 +221,43 @@ FMatrix FMatrix::GetScaleMatrix(const FVector& InScale)
 	return GetScaleMatrix(InScale.X, InScale.Y, InScale.Z);
 }
 
+
 FMatrix FMatrix::GetRotateMatrix(const FQuat& Q)
 {
-    // 쿼터니언 요소 추출
-    const float x = Q.X, y = Q.Y, z = Q.Z, w = Q.W;
+	// 쿼터니언 요소 추출
+	const float x = Q.X, y = Q.Y, z = Q.Z, w = Q.W;
 
-    // 중간 계산값
-    const float xx = x * x, yy = y * y, zz = z * z;
-    const float xy = x * y, xz = x * z, yz = y * z;
-    const float wx = w * x, wy = w * y, wz = w * z;
+	// 중간 계산값
+	const float xx = x * x, yy = y * y, zz = z * z;
+	const float xy = x * y, xz = x * z, yz = y * z;
+	const float wx = w * x, wy = w * y, wz = w * z;
 
-    // X, Y 축 회전 방향 반전 (부호 반전)
-    FMatrix Result;
+	// 회전 행렬 구성
+	FMatrix Result;
 
-    Result.M[0][0] = 1.0f - 2.0f * (yy + zz);
-    Result.M[1][0] = -2.0f * (xy - wz); // Y 축 반전
-    Result.M[2][0] = -2.0f * (xz + wy); // X 축 반전
-    Result.M[3][0] = 0.0f;
+	Result.M[0][0] = 1.0f - 2.0f * (yy + zz);
+	Result.M[0][1] = 2.0f * (xy - wz);
+	Result.M[0][2] = 2.0f * (xz + wy);
+	Result.M[0][3] = 0.0f;
 
-    Result.M[0][1] = -2.0f * (xy + wz); // Y 축 반전
-    Result.M[1][1] = 1.0f - 2.0f * (xx + zz);
-    Result.M[2][1] = -2.0f * (yz - wx); // X 축 반전
-    Result.M[3][1] = 0.0f;
+	Result.M[1][0] = 2.0f * (xy + wz);
+	Result.M[1][1] = 1.0f - 2.0f * (xx + zz);
+	Result.M[1][2] = 2.0f * (yz - wx);
+	Result.M[1][3] = 0.0f;
 
-    Result.M[0][2] = -2.0f * (xz - wy); // X 축 반전
-    Result.M[1][2] = -2.0f * (yz + wx); // Y 축 반전
-    Result.M[2][2] = 1.0f - 2.0f * (xx + yy);
-    Result.M[3][2] = 0.0f;
+	Result.M[2][0] = 2.0f * (xz - wy);
+	Result.M[2][1] = 2.0f * (yz + wx);
+	Result.M[2][2] = 1.0f - 2.0f * (xx + yy);
+	Result.M[2][3] = 0.0f;
 
-    Result.M[0][3] = 0.0f;
-    Result.M[1][3] = 0.0f;
-    Result.M[2][3] = 0.0f;
-    Result.M[3][3] = 1.0f;
+	Result.M[3][0] = 0.0f;
+	Result.M[3][1] = 0.0f;
+	Result.M[3][2] = 0.0f;
+	Result.M[3][3] = 1.0f; // 4x4 행렬이므로 마지막 값은 1
 
-    return Result;
+	return Result;
 }
+
 
 
 /// <summary>

--- a/Source/Core/Math/Transform.h
+++ b/Source/Core/Math/Transform.h
@@ -100,8 +100,8 @@ public:
 		// 회전 행렬의 첫 번째 열이 Forward 벡터를 나타냄
 		FVector Forward = FVector(
 			RotationMatrix.M[0][0],
-			-RotationMatrix.M[1][0],
-			-RotationMatrix.M[2][0]
+			RotationMatrix.M[1][0],
+			RotationMatrix.M[2][0]
 		);
 
 		return Forward.GetSafeNormal();
@@ -115,6 +115,33 @@ public:
 	FVector GetUp() const {
 		return FVector::CrossProduct(GetForward(), GetRight()).GetSafeNormal();
 
+	}
+
+
+	FVector GetLocalRight() const
+	{
+		FMatrix RotationMatrix = FMatrix::GetRotateMatrix(Rotation);
+
+		FVector Right = FVector(
+			RotationMatrix.M[0][1],  // 첫 번째 열이 Right 벡터
+			RotationMatrix.M[1][1],
+			RotationMatrix.M[2][1]
+		);
+
+		return Right.GetSafeNormal();
+	}
+
+	FVector GetLocalUp() const
+	{
+		FMatrix RotationMatrix = FMatrix::GetRotateMatrix(Rotation);
+
+		FVector up = FVector(
+			RotationMatrix.M[0][2],  // 첫 번째 열이 Right 벡터
+			RotationMatrix.M[1][2],
+			RotationMatrix.M[2][2]
+		);
+
+		return up.GetSafeNormal();
 	}
 
 	void Translate(const FVector& InTranslation)
@@ -152,10 +179,16 @@ public:
 
 	void MoveLocal(const FVector& LocalDelta)
 	{
-		Position += GetForward() * LocalDelta.X;
-		Position += GetRight() * LocalDelta.Y;
-		Position += GetUp() * LocalDelta.Z;
+		// 현재 변환 행렬 (Scale * Rotation * Translation)
+		FMatrix TransformMatrix = GetMatrix();
+
+		// 로컬 이동 벡터를 월드 이동 벡터로 변환
+		FVector WorldDelta = TransformMatrix.TransformVector(LocalDelta);
+
+		// 최종적으로 이동 적용
+		Position += WorldDelta;
 	}
+
 
 
 

--- a/Source/Core/Math/Transform.h
+++ b/Source/Core/Math/Transform.h
@@ -133,7 +133,7 @@ public:
 	void RotateYaw(float Angle)
 	{
 		FVector Axis = FVector(0, 0, 1);
-		Rotation = FQuat::MultiplyQuaternions(Rotation, FQuat(Axis, Angle));
+		Rotation = FQuat::MultiplyQuaternions(FQuat(Axis, Angle),Rotation);
 
 		//Rotation = FQuat::MultiplyQuaternions(Rotation, FQuat(0, 0, sin(Angle * TORAD / 2), cos(Angle * TORAD / 2)));
 	}
@@ -141,13 +141,13 @@ public:
 	void RotatePitch(float Angle)
 	{
 		FVector Axis = FVector(0, 1, 0).GetSafeNormal();
-		Rotation = FQuat::MultiplyQuaternions(Rotation, FQuat(Axis, Angle));
+		Rotation = FQuat::MultiplyQuaternions(FQuat(Axis, Angle), Rotation);
 	}
 
 	void RotateRoll(float Angle)
 	{
 		FVector Axis = FVector(1, 0, 0).GetSafeNormal();
-		Rotation = FQuat::MultiplyQuaternions(Rotation, FQuat(Axis, Angle));
+		Rotation = FQuat::MultiplyQuaternions(FQuat(Axis, Angle), Rotation);
 	}
 
 	void MoveLocal(const FVector& LocalDelta)

--- a/Source/Core/Rendering/BufferCache.cpp
+++ b/Source/Core/Rendering/BufferCache.cpp
@@ -66,6 +66,13 @@ BufferInfo FBufferCache::CreateVertexBufferInfo(EPrimitiveType Type)
 		Buffer = UEngine::Get().GetRenderer()->CreateVertexBuffer(Vertices.GetData(), sizeof(FVertexSimple) * Size);
 		break;
 	}
+	case EPrimitiveType::EPT_Circle:
+	{
+		TArray<FVertexSimple> Vertices = CreateCircleVertices();
+		Size = Vertices.Num();
+		Buffer = UEngine::Get().GetRenderer()->CreateVertexBuffer(Vertices.GetData(), sizeof(FVertexSimple) * Size);
+		break;
+	}
 	}
 
 	return BufferInfo(Buffer, Size, Topology);
@@ -148,3 +155,110 @@ TArray<FVertexSimple> FBufferCache::CreateCylinderVertices()
 
 	return vertices;
 }
+
+TArray<FVertexSimple> FBufferCache::CreateCircleVertices()
+{
+    TArray<FVertexSimple> vertices;
+
+    int DISC_RESOLUTION = 128; // 원을 구성하는 정점 개수
+    float outerRadius = 1.0f;  // 외곽 반지름
+    float innerRadius = 0.9f;  // 내부 반지름
+    float height = 0.1f;       // 원기둥의 두께
+    float angleStep = 2.0f * PI / DISC_RESOLUTION;
+
+    // 위쪽 원 (Top) - CCW (반시계 방향)
+    for (int i = 0; i < DISC_RESOLUTION; ++i)
+    {
+        float angle = i * angleStep;
+        float nextAngle = (i + 1) * angleStep;
+
+        float x0 = cos(angle);
+        float z0 = sin(angle);
+        float x1 = cos(nextAngle);
+        float z1 = sin(nextAngle);
+
+        // 삼각형 1 (탑면)
+        vertices.Add({ x0 * outerRadius, height / 2, z0 * outerRadius, 1, 1, 1, 1 });
+        vertices.Add({ x0 * innerRadius, height / 2, z0 * innerRadius, 1, 1, 1, 1 });
+        vertices.Add({ x1 * outerRadius, height / 2, z1 * outerRadius, 1, 1, 1, 1 });
+
+        // 삼각형 2 (탑면)
+        vertices.Add({ x0 * innerRadius, height / 2, z0 * innerRadius, 1, 1, 1, 1 });
+        vertices.Add({ x1 * innerRadius, height / 2, z1 * innerRadius, 1, 1, 1, 1 });
+        vertices.Add({ x1 * outerRadius, height / 2, z1 * outerRadius, 1, 1, 1, 1 });
+    }
+
+    // 바닥면 (Bottom) - CW (시계 방향)
+    for (int i = 0; i < DISC_RESOLUTION; ++i)
+    {
+        float angle = i * angleStep;
+        float nextAngle = (i + 1) * angleStep;
+
+        float x0 = cos(angle);
+        float z0 = sin(angle);
+        float x1 = cos(nextAngle);
+        float z1 = sin(nextAngle);
+
+        // 삼각형 1 (바닥면)
+        vertices.Add({ x1 * outerRadius, -height / 2, z1 * outerRadius, 1, 1, 1, 1 });
+        vertices.Add({ x0 * innerRadius, -height / 2, z0 * innerRadius, 1, 1, 1, 1 });
+        vertices.Add({ x0 * outerRadius, -height / 2, z0 * outerRadius, 1, 1, 1, 1 });
+
+        // 삼각형 2 (바닥면)
+        vertices.Add({ x1 * outerRadius, -height / 2, z1 * outerRadius, 1, 1, 1, 1 });
+        vertices.Add({ x1 * innerRadius, -height / 2, z1 * innerRadius, 1, 1, 1, 1 });
+        vertices.Add({ x0 * innerRadius, -height / 2, z0 * innerRadius, 1, 1, 1, 1 });
+    }
+
+    // 측면 벽 추가 (외곽) - 시계 방향 (CW)
+    for (int i = 0; i < DISC_RESOLUTION; ++i)
+    {
+        float angle = i * angleStep;
+        float nextAngle = (i + 1) * angleStep;
+
+        float x0 = cos(angle);
+        float z0 = sin(angle);
+        float x1 = cos(nextAngle);
+        float z1 = sin(nextAngle);
+
+        // 삼각형 1 (외곽 벽면)
+        vertices.Add({ x0 * outerRadius, height / 2, z0 * outerRadius, 1, 1, 1, 1 });
+        
+        vertices.Add({ x1 * outerRadius, height / 2, z1 * outerRadius, 1, 1, 1, 1 });
+		vertices.Add({ x0 * outerRadius, -height / 2, z0 * outerRadius, 1, 1, 1, 1 });
+
+        // 삼각형 2 (외곽 벽면)
+        vertices.Add({ x0 * outerRadius, -height / 2, z0 * outerRadius, 1, 1, 1, 1 });
+        
+        vertices.Add({ x1 * outerRadius, height / 2, z1 * outerRadius, 1, 1, 1, 1 });
+		vertices.Add({ x1 * outerRadius, -height / 2, z1 * outerRadius, 1, 1, 1, 1 });
+    }
+
+    // 측면 벽 추가 (내부) - 반시계 방향 (CCW)
+    for (int i = 0; i < DISC_RESOLUTION; ++i)
+    {
+        float angle = i * angleStep;
+        float nextAngle = (i + 1) * angleStep;
+
+        float x0 = cos(angle);
+        float z0 = sin(angle);
+        float x1 = cos(nextAngle);
+        float z1 = sin(nextAngle);
+
+        // 삼각형 1 (내부 벽면)
+        vertices.Add({ x0 * innerRadius, height / 2, z0 * innerRadius, 1, 1, 1, 1 });
+        
+        vertices.Add({ x0 * innerRadius, -height / 2, z0 * innerRadius, 1, 1, 1, 1 });
+		vertices.Add({ x1 * innerRadius, height / 2, z1 * innerRadius, 1, 1, 1, 1 });
+
+        // 삼각형 2 (내부 벽면)
+        vertices.Add({ x0 * innerRadius, -height / 2, z0 * innerRadius, 1, 1, 1, 1 });
+        
+        vertices.Add({ x1 * innerRadius, -height / 2, z1 * innerRadius, 1, 1, 1, 1 });
+		vertices.Add({ x1 * innerRadius, height / 2, z1 * innerRadius, 1, 1, 1, 1 });
+    }
+
+    return vertices;
+}
+
+

--- a/Source/Core/Rendering/BufferCache.h
+++ b/Source/Core/Rendering/BufferCache.h
@@ -8,6 +8,7 @@
 #include "Primitive/PrimitiveVertices.h"
 #include "Core/Container/Array.h"
 
+
 struct BufferInfo
 {
 public:
@@ -45,7 +46,7 @@ public:
 	TArray<FVertexSimple> CreateArrowVertices();
 	TArray<FVertexSimple> CreateConeVertices();
 	TArray<FVertexSimple> CreateCylinderVertices();
-
+	TArray<FVertexSimple> CreateCircleVertices();
 private :
 	BufferInfo CreateVertexBufferInfo(EPrimitiveType Type);
 };

--- a/Source/Core/Rendering/UI.cpp
+++ b/Source/Core/Rendering/UI.cpp
@@ -16,6 +16,7 @@
 #include "Object/Actor/Arrow.h"
 #include "Object/Actor/Cone.h"
 #include "Object/Actor/Cylinder.h"
+#include "Object/Actor/Circle.h"
 #include "Static/FEditorManager.h"
 #include "Object/World/World.h"
 #include "Object/Gizmo/GizmoHandle.h"
@@ -154,7 +155,7 @@ void UI::RenderMemoryUsage()
 
 void UI::RenderPrimitiveSelection()
 {
-    const char* items[] = { "Sphere", "Cube", "Cylinder", "Cone" };
+    const char* items[] = { "Sphere", "Cube", "Cylinder", "Cone","Circle"};
 
     ImGui::Combo("Primitive", &currentItem, items, IM_ARRAYSIZE(items));
 
@@ -178,6 +179,10 @@ void UI::RenderPrimitiveSelection()
             else if (strcmp(items[currentItem], "Cone") == 0)
             {
                 World->SpawnActor<ACone>();
+            }
+            else if (strcmp(items[currentItem], "Circle") == 0)
+            {
+                World->SpawnActor<ACircle>();
             }
             //else if (strcmp(items[currentItem], "Triangle") == 0)
             //{

--- a/Source/Core/Rendering/URenderer.cpp
+++ b/Source/Core/Rendering/URenderer.cpp
@@ -408,7 +408,7 @@ void URenderer::CreateRasterizerState()
 {
     D3D11_RASTERIZER_DESC RasterizerDesc = {};
     RasterizerDesc.FillMode = D3D11_FILL_SOLID; // 채우기 모드
-    RasterizerDesc.FillMode = D3D11_FILL_WIREFRAME;
+   // RasterizerDesc.FillMode = D3D11_FILL_WIREFRAME;
     RasterizerDesc.CullMode = D3D11_CULL_BACK;  // 백 페이스 컬링
     RasterizerDesc.FrontCounterClockwise = FALSE;
 

--- a/Source/Object/Actor/Circle.cpp
+++ b/Source/Object/Actor/Circle.cpp
@@ -1,0 +1,28 @@
+﻿#include "Circle.h"
+
+#include <Object/PrimitiveComponent/UPrimitiveComponent.h>
+
+ACircle::ACircle()
+{
+    bCanEverTick = true;
+
+    UCylinderComp* CylinderComponent = AddComponent<UCylinderComp>();
+    RootComponent = CylinderComponent;
+
+    SetActorTransform(FTransform());
+}
+
+void ACircle::BeginPlay()
+{
+    Super::BeginPlay();
+}
+
+void ACircle::Tick(float DeltaTime)
+{
+    Super::Tick(DeltaTime);
+}
+
+const char* ACircle::GetTypeName()
+{
+    return "Circle";
+}

--- a/Source/Object/Actor/Circle.h
+++ b/Source/Object/Actor/Circle.h
@@ -1,0 +1,14 @@
+﻿#pragma once
+#include "Object/Actor/Actor.h"
+
+class ACircle : public AActor
+{
+    using Super = AActor;
+public:
+    ACircle();
+    virtual ~ACircle() = default;
+    virtual void BeginPlay() override;
+    virtual void Tick(float DeltaTime) override;
+    virtual const char* GetTypeName() override;
+};
+

--- a/Source/Object/Actor/Picker.cpp
+++ b/Source/Object/Actor/Picker.cpp
@@ -95,19 +95,37 @@ void APicker::LateTick(float DeltaTime)
             if (AGizmoHandle* Gizmo = dynamic_cast<AGizmoHandle*>(PickedComponent->GetOwner()))
             {
                 if (Gizmo->GetSelectedAxis() != ESelectedAxis::None) return;
-                UCylinderComp* CylinderComp = static_cast<UCylinderComp*>(PickedComponent);
-                FVector4 CompColor = CylinderComp->GetCustomColor();
-                if (1.0f - FMath::Abs(CompColor.X) < KINDA_SMALL_NUMBER) // Red - X축
+                if(UCylinderComp* CylinderComp = dynamic_cast<UCylinderComp*>(PickedComponent))
                 {
-                    Gizmo->SetSelectedAxis(ESelectedAxis::X);
+                    FVector4 CompColor = CylinderComp->GetCustomColor();
+                    if (1.0f - FMath::Abs(CompColor.X) < KINDA_SMALL_NUMBER) // Red - X축
+                    {
+                        Gizmo->SetSelectedAxis(ESelectedAxis::X);
+                    }
+                    else if (1.0f - FMath::Abs(CompColor.Y) < KINDA_SMALL_NUMBER) // Green - Y축
+                    {
+                        Gizmo->SetSelectedAxis(ESelectedAxis::Y);
+                    }
+                    else  // Blue - Z축
+                    {
+                        Gizmo->SetSelectedAxis(ESelectedAxis::Z);
+                    }
                 }
-                else if (1.0f - FMath::Abs(CompColor.Y) < KINDA_SMALL_NUMBER) // Green - Y축
+                else if (UCircleComp* CylinderComp = dynamic_cast<UCircleComp*>(PickedComponent))
                 {
-                    Gizmo->SetSelectedAxis(ESelectedAxis::Y);
-                }
-                else  // Blue - Z축
-                {
-                    Gizmo->SetSelectedAxis(ESelectedAxis::Z);
+                    FVector4 CompColor = CylinderComp->GetCustomColor();
+                    if (1.0f - FMath::Abs(CompColor.X) < KINDA_SMALL_NUMBER) // Red - X축
+                    {
+                        Gizmo->SetSelectedAxis(ESelectedAxis::X);
+                    }
+                    else if (1.0f - FMath::Abs(CompColor.Y) < KINDA_SMALL_NUMBER) // Green - Y축
+                    {
+                        Gizmo->SetSelectedAxis(ESelectedAxis::Y);
+                    }
+                    else  // Blue - Z축
+                    {
+                        Gizmo->SetSelectedAxis(ESelectedAxis::Z);
+                    }
                 }
             }
         }

--- a/Source/Object/Gizmo/GizmoHandle.cpp
+++ b/Source/Object/Gizmo/GizmoHandle.cpp
@@ -1,5 +1,4 @@
 ﻿#include "GizmoHandle.h"
-
 #include "Object/Actor/Camera.h"
 #include "Object/PrimitiveComponent/UPrimitiveComponent.h"
 #include "Object/World/World.h"
@@ -25,16 +24,39 @@ AGizmoHandle::AGizmoHandle()
 
 
 	// y
-	UCylinderComp* YArrow = AddComponent<UCylinderComp>();
+	/**/UCylinderComp* YArrow = AddComponent<UCylinderComp>();
 	YArrow->SetupAttachment(ZArrow);
 	YArrow->SetRelativeTransform(FTransform(FVector(0.0f, 0.0f, 0.0f), FVector(90.0f, 0.0f, 0.0f), FVector(1, 1, 1)));
 	YArrow->SetCustomColor(FVector4(0.0f, 1.0f, 0.0f, 1.0f));
 	CylinderComponents.Add(YArrow);
+
+	UCircleComp* ZCircle = AddComponent<UCircleComp>();
+	ZCircle->SetupAttachment(ZArrow);
+	ZCircle->SetRelativeTransform(FTransform(FVector(0.0f, 0.0f, 0.0f), FVector(90.0f, 0.0f, 0.0f), FVector(1, 1, 1)));
+	ZCircle->SetCustomColor(FVector4(0.0f, 0.0f, 1.0f, 1.0f));
+	CircleComponents.Add(ZCircle);
+
+	// x
+	UCircleComp* XCircle = AddComponent<UCircleComp>();
+	XCircle->SetupAttachment(ZArrow);
+	XCircle->SetRelativeTransform(FTransform(FVector(0.0f, 0.0f, 0.0f), FVector(0.0f, 0.0f, 90.0f), FVector(1, 1, 1)));
+	XCircle->SetCustomColor(FVector4(1.0f, 0.0f, 0.0f, 1.0f));
+	CircleComponents.Add(XCircle);
+
+	UCircleComp* YCircle = AddComponent<UCircleComp>();
+	YCircle->SetupAttachment(ZArrow);
+	YCircle->SetRelativeTransform(FTransform(FVector(0.0f, 0.0f, 0.0f), FVector(0.0f, 0.0f, 0.0f), FVector(1, 1, 1)));
+	YCircle->SetCustomColor(FVector4(0.0f, 1.0f, 0.0f, 1.0f));
+	CircleComponents.Add(YCircle);
+
 	RootComponent = ZArrow;
 
 	UEngine::Get().GetWorld()->AddZIgnoreComponent(ZArrow);
 	UEngine::Get().GetWorld()->AddZIgnoreComponent(XArrow);
 	UEngine::Get().GetWorld()->AddZIgnoreComponent(YArrow);
+	UEngine::Get().GetWorld()->AddZIgnoreComponent(ZCircle);
+	UEngine::Get().GetWorld()->AddZIgnoreComponent(XCircle);
+	UEngine::Get().GetWorld()->AddZIgnoreComponent(YCircle);
 
 	SetActive(false);
 }
@@ -114,6 +136,28 @@ void AGizmoHandle::Tick(float DeltaTime)
 		int type = static_cast<int>(GizmoType);
 		type = (type + 1) % static_cast<int>(EGizmoType::Max);
 		GizmoType = static_cast<EGizmoType>(type);
+		if (GizmoType == EGizmoType::Rotate)
+		{
+			for (auto& Circle : CircleComponents)
+			{
+				Circle->SetCanBeRendered(true);
+			}
+			for (auto& Cylinder : CylinderComponents)
+			{
+				Cylinder->SetCanBeRendered(false);
+			}
+		}
+		else
+		{
+			for (auto& Cylinder : CylinderComponents)
+			{
+				Cylinder->SetCanBeRendered(true);
+			}
+			for (auto& Circle : CircleComponents)
+			{
+				Circle->SetCanBeRendered(false);
+			}
+		}
 	}
 
 }
@@ -146,9 +190,41 @@ void AGizmoHandle::SetScaleByDistance()
 void AGizmoHandle::SetActive(bool bActive)
 {
 	bIsActive = bActive;
-	for (auto& Cylinder : CylinderComponents)
+	if (bIsActive)
 	{
-		Cylinder->SetCanBeRendered(bActive);
+		if (GizmoType == EGizmoType::Rotate)
+		{
+			for (auto& Circle : CircleComponents)
+			{
+				Circle->SetCanBeRendered(bActive);
+			}
+			for (auto& Cylinder : CylinderComponents)
+			{
+				Cylinder->SetCanBeRendered(!bActive);
+			}
+		}
+		else
+		{
+			for (auto& Cylinder : CylinderComponents)
+			{
+				Cylinder->SetCanBeRendered(bActive);
+			}
+			for (auto& Circle : CircleComponents)
+			{
+				Circle->SetCanBeRendered(!bActive);
+			}
+		}
+	}
+	else
+	{
+		for (auto& Cylinder : CylinderComponents)
+		{
+			Cylinder->SetCanBeRendered(false);
+		}
+		for (auto& Circle : CircleComponents)
+		{
+			Circle->SetCanBeRendered(false);
+		}
 	}
 }
 

--- a/Source/Object/Gizmo/GizmoHandle.h
+++ b/Source/Object/Gizmo/GizmoHandle.h
@@ -33,6 +33,7 @@ public:
 private:
 	bool bIsActive = false;
 	TArray<class UCylinderComp*> CylinderComponents;
+	TArray<class UCircleComp*> CircleComponents;
 
 	ESelectedAxis SelectedAxis = ESelectedAxis::None;
 	EGizmoType GizmoType = EGizmoType::Translate;

--- a/Source/Object/PrimitiveComponent/UPrimitiveComponent.h
+++ b/Source/Object/PrimitiveComponent/UPrimitiveComponent.h
@@ -143,3 +143,19 @@ public:
 		return EPrimitiveType::EPT_Cone;
 	}
 };
+
+class UCircleComp : public UPrimitiveComponent
+{
+	using Super = UPrimitiveComponent;
+
+public:
+	UCircleComp()
+	{
+		bCanBeRendered = true;
+	}
+	virtual ~UCircleComp() = default;
+	EPrimitiveType GetType() override
+	{
+		return EPrimitiveType::EPT_Circle;
+	}
+};

--- a/Source/Object/World/World.cpp
+++ b/Source/Object/World/World.cpp
@@ -10,6 +10,7 @@
 #include "Object/Actor/Cone.h"
 #include "Object/Actor/Cube.h"
 #include "Object/Actor/Cylinder.h"
+#include "Object/Actor/Circle.h"
 #include "Object/Actor/Sphere.h"
 #include "Object/PrimitiveComponent/UPrimitiveComponent.h"
 #include "Static/FEditorManager.h"
@@ -240,6 +241,10 @@ void UWorld::LoadWorld(const char* SceneName)
 		else if (ObjectInfo->ObjectType == "Cone")
 		{
 			Actor = SpawnActor<ACone>();
+		}
+		else if (ObjectInfo->ObjectType == "Circle")
+		{
+			Actor = SpawnActor<ACircle>();
 		}
 		
 		Actor->SetActorTransform(Transform);

--- a/Source/Primitive/PrimitiveVertices.h
+++ b/Source/Primitive/PrimitiveVertices.h
@@ -15,6 +15,7 @@ enum class EPrimitiveType : uint8
 	EPT_Line,
 	EPT_Cylinder,
 	EPT_Cone,
+	EPT_Circle,
 	EPT_Max,
 };
 

--- a/imgui.ini
+++ b/imgui.ini
@@ -7,8 +7,8 @@ Pos=628,6
 Size=347,223
 
 [Window][Jungle Control Panel]
-Pos=90,97
-Size=298,493
+Pos=-13,-13
+Size=442,376
 
 [Window][Jungle Property Window]
 Pos=870,21
@@ -19,10 +19,10 @@ Pos=3,831
 Size=613,142
 
 [Window][Console]
-Pos=815,74
-Size=402,304
+Pos=782,19
+Size=438,317
 
 [Window][Properties]
-Pos=517,120
-Size=266,271
+Pos=842,365
+Size=346,330
 

--- a/imgui.ini
+++ b/imgui.ini
@@ -7,8 +7,8 @@ Pos=628,6
 Size=347,223
 
 [Window][Jungle Control Panel]
-Pos=94,84
-Size=202,206
+Pos=90,97
+Size=298,493
 
 [Window][Jungle Property Window]
 Pos=870,21
@@ -19,7 +19,7 @@ Pos=3,831
 Size=613,142
 
 [Window][Console]
-Pos=518,136
+Pos=815,74
 Size=402,304
 
 [Window][Properties]

--- a/imgui.ini
+++ b/imgui.ini
@@ -7,8 +7,8 @@ Pos=628,6
 Size=347,223
 
 [Window][Jungle Control Panel]
-Pos=-13,-9
-Size=302,269
+Pos=94,84
+Size=202,206
 
 [Window][Jungle Property Window]
 Pos=870,21
@@ -19,10 +19,10 @@ Pos=3,831
 Size=613,142
 
 [Window][Console]
-Pos=703,111
-Size=343,419
+Pos=518,136
+Size=402,304
 
 [Window][Properties]
-Pos=336,223
-Size=267,277
+Pos=517,120
+Size=266,271
 

--- a/t0.vcxproj
+++ b/t0.vcxproj
@@ -161,6 +161,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="Circle.cpp" />
     <ClCompile Include="Source\Core\HAL\StackAllocator.cpp" />
     <ClCompile Include="Source\Core\Math\Plane.cpp" />
     <ClCompile Include="Source\Object\Actor\Camera.cpp" />
@@ -205,6 +206,7 @@
     </FxCompile>
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="Circle.h" />
     <ClInclude Include="Source\Core\HAL\StackAllocator.h" />
     <ClInclude Include="Source\Object\Actor\Camera.h" />
     <ClInclude Include="Source\Object\Actor\Cone.h" />


### PR DESCRIPTION
속이 빈 원기둥 만드는 코드 추가.
기존 primitive와 동일하게 원기둥을 만드는 버텍스 버퍼를 따로 생성
Primitive type을 EPT_Circle로 지정하여 생성할 수 있음

기즈모의 type이 Rotate일 때 Rotate Gizmo로 사용가능
조작 방식은 언리얼 엔진과 동일 (X : Roll, y:picth ,z:Yaw)

조작과 피킹이  컬러 피킹을 사용하는 기존 기즈모와 동일해 조작감의 개선이 필요하긴합니다.

피킹은  속이 빈 원기둥이라 AABB로 하기에는 무리가 있어 보입니다
